### PR TITLE
Add beginner-friendly documentation for ls command

### DIFF
--- a/linux/basics/ls.md
+++ b/linux/basics/ls.md
@@ -1,0 +1,22 @@
+# ls
+
+## What it does
+The `ls` command lists files and directories in the current working directory.
+
+## Example usage
+```bash
+ls
+````
+
+## Example output
+
+```text
+documents  downloads  notes.txt
+```
+
+````
+
+Save and exit:
+- Press `Ctrl + O` → Enter
+- Press `Ctrl + X`
+


### PR DESCRIPTION
This PR adds beginner-friendly documentation for the `ls` command under `linux/basics/`.